### PR TITLE
Add option to inline templates with angular2-template-loader

### DIFF
--- a/wallaby.js
+++ b/wallaby.js
@@ -8,6 +8,8 @@ var webpackPostprocessor = wallabyWebpack({
 
   module: {
     loaders: [
+      // if you use templateUrl in your components and want to inline your templates uncomment the below line
+      // {test: /\.js$/, loader: 'angular2-template-loader', exclude: /node_modules/},
       {test: /\.css$/, loader: 'raw-loader'},
       {test: /\.json$/, loader: 'json-loader'},
       {test: /\.html$/, loader: 'raw-loader'},


### PR DESCRIPTION
* **What kind of change does this PR introduce?** 
Adds a commented out option for using angular2-template-loader to inline templates included in 
components with templateUrl

* **What is the current behavior?** (You can also link to an open issue here)

Currently if you have existing tests running in Karma using angular2-template-loader, when running
wallaby.js on same tests you get an error about components needing to be compiled.

* **What is the new behavior (if this is a feature change)?**

If this line is commented out the templateUrl based component tests will complete the same as they
do in Karma/Webpack with this settings

Just happened to find this noted within text of a closed issue - could be handy to have noted explicitly here.