### PR TITLE
Add commented out options for handling scss and webpack defined globals

### DIFF
--- a/wallaby.js
+++ b/wallaby.js
@@ -1,4 +1,8 @@
 var wallabyWebpack = require('wallaby-webpack');
+// if you use the webpack defined variable ENV in any components 
+// uncomment the following lines and the plugins section in webpackPostprocessor below
+//const DefinePlugin = require('webpack/lib/DefinePlugin');
+//const ENV = process.env.ENV = process.env.NODE_ENV = 'test';
 
 var webpackPostprocessor = wallabyWebpack({
   entryPatterns: [
@@ -10,12 +14,20 @@ var webpackPostprocessor = wallabyWebpack({
     loaders: [
       // if you use templateUrl in your components and want to inline your templates uncomment the below line
       // {test: /\.js$/, loader: 'angular2-template-loader', exclude: /node_modules/},
+      
+      // if importing .scss files in your component styleUrls uncomment the following line
+      // { test: /\.scss$/, loaders: ['raw-loader', 'sass-loader'] },
       {test: /\.css$/, loader: 'raw-loader'},
       {test: /\.json$/, loader: 'json-loader'},
       {test: /\.html$/, loader: 'raw-loader'},
       {test: /karma-require/, loader: 'null'}
     ]
-  }
+  },
+   // plugins: [
+   //     new DefinePlugin({
+   //       'ENV': JSON.stringify(ENV)
+   //     })
+   // ]
 });
 
 module.exports = function () {


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Just a comment update to provide users with details about how to cope with .scss files in component styleUrls and also if the webpack defined ENV is used in any components. This may be useful to other people, but just ignore if you think it starts cluttering the file too much and you would prefer it in the README or something.